### PR TITLE
separating code that only works locally and code that works on aws

### DIFF
--- a/src/http-common.js
+++ b/src/http-common.js
@@ -1,19 +1,4 @@
 import axios from "axios";
-// var AXIOS = {};
-
-// if( process.env.NODE_ENV === 'development' ){
-//   AXIOS = {
-//     baseURL: "http://localhost:3027/course-jt/",
-//     headers: { "Content-Type": "application/json" }
-//   }
-// } else {
-//   AXIOS =  {
-//     base: "/course-jt",
-//     headers: { "Content-Type": "application/json" }
-//   }
-// }
-
-// export default axios.create(AXIOS);
 
 /*** works locally ***/
 // export default axios.create({
@@ -23,6 +8,6 @@ import axios from "axios";
 
 /*** works aws ***/
 export default axios.create({
-  base: process.env.NODE_ENV === 'development' ? "http://localhost/" : "/course-jt",
+  base: process.env.NODE_ENV === 'development' ? "http://localhost:3027/course-jt" : "/course-jt",
   headers: { "Content-Type": "application/json" }
 });


### PR DESCRIPTION
when creating axios, aws will only work with the 'base' attribute. localhost needs 'baseURL' to find the paths